### PR TITLE
Add fallback to use local rhyme db if not installed

### DIFF
--- a/rhyme.py
+++ b/rhyme.py
@@ -2,7 +2,12 @@
 import sqlite3 as sql
 import sys, os, os.path
 
-_conn = sql.connect(os.path.join(sys.prefix, 'data/rhyme.db'))
+_rhymedb_path = os.path.join(sys.prefix, 'data/rhyme.db')
+try:
+    _conn = sql.connect(_rhymedb_path)
+except sql.OperationalError:
+    _rhymedb_path = os.path.join(os.path.dirname(sys.argv[0]), 'data/rhyme.db')
+    _conn = sql.connect(_rhymedb_path) # if it fails again, let it crash
 
 def rhymes_with(word):
     """Returns a list of words that rhyme, or [] if no words rhyme."""
@@ -13,7 +18,7 @@ def rhymes_with(word):
     word, sound, key = row
     cursor = _conn.execute("select * from rhymes where sound=?", (sound,))
     sound, words = cursor.fetchone()
-    
+
     #return all the matching words. If a word has a (n) on it, clip it off,
     #and also don't return the original word
     return [x.split('(')[0] for x in words.split() if x.lower() != word.lower()]
@@ -21,6 +26,6 @@ def rhymes_with(word):
 def main():
     for word in sys.argv[1:]:
         print '%s: %s' % (word, ', '.join(rhymes_with(word)))
-        
+
 
 main() if __name__=='__main__' else None


### PR DESCRIPTION
I just needed to use the default command-line here instead of fully installing it. Thought about adding logging, but not sure what the 'pythonic' way to do that is.